### PR TITLE
Improve PHP 8.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1",
         "ext-bcmath": "*",
         "simplito/elliptic-php": "^1.0",
-        "stephenhill/base58": "^1.1",
+        "stephenhill/base58": "^1.1|^2",
         "kornrunner/keccak": "^1.0",
         "bitwasp/bech32": "^0.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1",
         "ext-bcmath": "*",
         "simplito/elliptic-php": "^1.0",
-        "stephenhill/base58": "^1.1|^2",
+        "stephenhill/base58": "^1.1||^2",
         "kornrunner/keccak": "^1.0",
         "bitwasp/bech32": "^0.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ec8b777d879b20ac47043d0ea7c4f3f",
+    "content-hash": "9629a4362365a1a4d3c65e4f52201a5c",
     "packages": [
         {
             "name": "bitwasp/bech32",


### PR DESCRIPTION
> PHP Deprecated:  StephenHill\Base58::__construct(): Implicitly marking parameter $service as nullable is deprecated, the explicit nullable type must be used instead in /path/to/vendor/stephenhill/base58/src/Base58.php on line 29

`composer require stephenhill/base58:"^1.1|^2"`

Tests pass.
