### PR TITLE
Fix PHP 8.2 dynamic property deprecation

### DIFF
--- a/src/XPub.php
+++ b/src/XPub.php
@@ -106,22 +106,22 @@ class XPub {
     /**
      * @var string $version 'xpub'|'tpub'|'ypub'|'upub'|'zpub'|'vpub'.
      */
-    protected $version;
+    public $version;
 
     /** @var int $depth */
-    protected $depth;
+    public $depth;
 
     /** @var string $parent_fingerprint */
-    protected $parent_fingerprint;
+    public $parent_fingerprint;
 
     /** @var int $index */
-    protected $index;
+    public $index;
 
     /** @var string $c */
-    protected $c;
+    public $c;
 
     /** @var string $K */
-    protected $K;
+    public $K;
 
     public function __construct(
         string $version,

--- a/src/XPub.php
+++ b/src/XPub.php
@@ -103,6 +103,26 @@ class XPub {
         }
     }
 
+    /**
+     * @var string $version 'xpub'|'tpub'|'ypub'|'upub'|'zpub'|'vpub'.
+     */
+    protected $version;
+
+    /** @var int $depth */
+    protected $depth;
+
+    /** @var string $parent_fingerprint */
+    protected $parent_fingerprint;
+
+    /** @var int $index */
+    protected $index;
+
+    /** @var string $c */
+    protected $c;
+
+    /** @var string $K */
+    protected $K;
+
     public function __construct(
         string $version,
         int $depth,

--- a/test/test.php
+++ b/test/test.php
@@ -302,7 +302,11 @@ echo "\n" . '🧪 Can convert xpubs:' . "\n";
     $expected_zpub = 'zpub6mwJaQaUE3oZ763dJZKRbNUxW1znc5f4uqty7hKaAS5RKNscWpZrkohNNhd7BNxD8Hj5NceNPbujdF3935mRkSHHcS6yZLnpsUkrK1XoMLr';
 
     $xpub = XPub::fromString($input_xpub);
-    $xpub->version = 'zpub';
+
+    $reflectionProperty = new ReflectionProperty(XPub::class, 'version');
+    $reflectionProperty->setAccessible(true);
+    $reflectionProperty->setValue($xpub, 'zpub');
+
     $output_zpub = $xpub->toString();
 
     if ($output_zpub !== $expected_zpub) {

--- a/test/test.php
+++ b/test/test.php
@@ -302,11 +302,7 @@ echo "\n" . '🧪 Can convert xpubs:' . "\n";
     $expected_zpub = 'zpub6mwJaQaUE3oZ763dJZKRbNUxW1znc5f4uqty7hKaAS5RKNscWpZrkohNNhd7BNxD8Hj5NceNPbujdF3935mRkSHHcS6yZLnpsUkrK1XoMLr';
 
     $xpub = XPub::fromString($input_xpub);
-
-    $reflectionProperty = new ReflectionProperty(XPub::class, 'version');
-    $reflectionProperty->setAccessible(true);
-    $reflectionProperty->setValue($xpub, 'zpub');
-
+    $xpub->version = 'zpub';
     $output_zpub = $xpub->toString();
 
     if ($output_zpub !== $expected_zpub) {


### PR DESCRIPTION
```
Deprecated: Creation of dynamic property Nimiq\XPub::$version is deprecated in /path/to/php-xpub/src/XPub.php on line 114
Deprecated: Creation of dynamic property Nimiq\XPub::$depth is deprecated in /path/to/php-xpub/src/XPub.php on line 115
Deprecated: Creation of dynamic property Nimiq\XPub::$parent_fingerprint is deprecated in /path/to/php-xpub/src/XPub.php on line 116
Deprecated: Creation of dynamic property Nimiq\XPub::$index is deprecated in /path/to/php-xpub/src/XPub.php on line 117
Deprecated: Creation of dynamic property Nimiq\XPub::$c is deprecated in /path/to/php-xpub/src/XPub.php on line 118
Deprecated: Creation of dynamic property Nimiq\XPub::$K is deprecated in /path/to/php-xpub/src/XPub.php on line 119
```

Reading: [PHP 8.2: Dynamic Properties are deprecated](https://php.watch/versions/8.2/dynamic-properties-deprecated)

I had originally set the properties to be `protected` but I see your documentation mentions setting the `$xpubInstance->version` property directly, so I've kept them `public` so there is no breaking change. (that change to the test isn't needed anymore)